### PR TITLE
docs: Fix a few typos

### DIFF
--- a/PyDark/engine.py
+++ b/PyDark/engine.py
@@ -176,7 +176,7 @@ class World(object):
 
 
 class Camera(object):
-    """Object that controlls which part of the map to render /
+    """Object that controls which part of the map to render /
        along with all other objects, including Player() instances."""
     def __init__(self, x, y, width=800, height=600):
         self.x = x
@@ -376,7 +376,7 @@ class DarkSprite(pygame.sprite.Sprite):
         self.subsprites = [] # Subsprites for this DarkSprite instance.
         self.parent_sprite = None # Parent DarkSprite of this DarkSprite (if any)
         self.sprite_list = None
-        self.text_location = None # Defines where to draw inputed text(if any)
+        self.text_location = None # Defines where to draw inputted text(if any)
         if sprite_list:
             self.sprite_list = sprite_list
         elif sprite_sheet:
@@ -641,7 +641,7 @@ class DarkSprite(pygame.sprite.Sprite):
         Parameters: indexes, time, loop.
         indexes: sub-list(slice).
         time: seconds between image animations(float).
-        loop: should we loop indefinetly during this animation? (boolean).
+        loop: should we loop indefinitely during this animation? (boolean).
         delta: string. the datetime.timedelta(delta) comparison. Valid values: hours, minutes, seconds, milliseconds, microseconds.
         """
         self.animations.append(
@@ -709,7 +709,7 @@ class Animation(object):
         self.indexes = indexes
         # time between animations in seconds.
         self.time = time_offset
-        # boolean specifying whether we should loop this animation indefinetly.
+        # boolean specifying whether we should loop this animation indefinitely.
         self.loop = loop
         # datetime.timedelta comparison value type
         self.delta = delta
@@ -770,7 +770,7 @@ class BaseSprite(pygame.sprite.Sprite):
 class DarkThread(threading.Thread):
     """A daemon-flagged threading.Thread instance."""
     def __init__(self, name, func, runafter=None, params=[]):
-        """This class requires 2 parameters, and can recieve another 2 optional parameters. (name, func, runafter, params). name is a string and must be unique. func is a function handle and defines which function to execute. runafter is a float that defines when we should run this function. params is a list consisting of optional parameters to pass to our function handle."""
+        """This class requires 2 parameters, and can receive another 2 optional parameters. (name, func, runafter, params). name is a string and must be unique. func is a function handle and defines which function to execute. runafter is a float that defines when we should run this function. params is a list consisting of optional parameters to pass to our function handle."""
         threading.Thread.__init__(self)
         self.daemon = True
         self.runafter = runafter
@@ -790,7 +790,7 @@ class Scene(object):
     """A scene is a presentation of objects and UI elements."""
     def __init__(self, surface, name):
         """This class takes two parameters: (surface, name). surface must be assigned to your game instance. name is a string and must be unique!"""
-        # wether or not we should "draw" or "display" this scene
+        # whether or not we should "draw" or "display" this scene
         self.display = True
         # list of objects to draw onto our Scene()
         self.objects = []
@@ -942,7 +942,7 @@ class Game(object):
                  center_window=True, FPS=30, online=False,
                  server_ip=None, server_port=None, protocol=None,
                  log_or_not=False, collision_checking=True, flags=None):
-        """parameters: (title, window_size, icon, center_window, FPS, online, server_ip, server_port, protocol, log_or_not, collison_checking, flags)"""
+        """parameters: (title, window_size, icon, center_window, FPS, online, server_ip, server_port, protocol, log_or_not, collision_checking, flags)"""
         self.debug = False
         self.clock = pygame.time.Clock()
         self.FPS = FPS
@@ -974,7 +974,7 @@ class Game(object):
         self.current_scene = self.current_scene
         # default backgroundColor
         self.backgroundColor = (0, 0, 0)
-        # wether or not we should center of our games window
+        # whether or not we should center of our games window
         if center_window is True:
             ui.center_window()
         # let us know if we connected to the server properly(if applicable)

--- a/PyDark/net.py
+++ b/PyDark/net.py
@@ -34,7 +34,7 @@ def encode_packet(data, numeric_base=4, seperator="5", reverse=True):
     data = string (payload)
     numeric_base = integer (numeric base to convert our character ordinal numbers)
     seperator = string (character or characters to split our encoded packet) [Ensure this character(s) is unique]
-    reverse = boolean (wether we should reverse our encoded packet or not)
+    reverse = boolean (whether we should reverse our encoded packet or not)
     """
     data = str(seperator).join([ord2base(ord(j), numeric_base) for j in data])
     if reverse:
@@ -50,7 +50,7 @@ def decode_packet(data, numeric_base=4, seperator="5", reverse=True):
     data = string (payload)
     numeric_base = integer (numeric base to decode our character ordinal numbers)
     seperator = string (character or characters to split our encoded packet) [Ensure this character(s) is unique]
-    reverse = boolean (wether we should reverse our packet data or not before decoding it)
+    reverse = boolean (whether we should reverse our packet data or not before decoding it)
     """
     if reverse:
         data = data[::-1]
@@ -101,7 +101,7 @@ class ClientProtocol(LineReceiver):
     def packetParser(self, line):
         """
         This function is in charge of 'splitting' the packet header from the packet payload.
-        By default, it seperates the header from the payload by splitting the packet data from its colon(:).
+        By default, it separates the header from the payload by splitting the packet data from its colon(:).
         """
         header, payload = line.split(":")
         return header, payload
@@ -163,13 +163,13 @@ class ServerProtocol(LineReceiver):
 
     def register_iterable(self, func):
         """
-        Register a function(class-method) that will run indefinetly on the server.
+        Register a function(class-method) that will run indefinitely on the server.
         """
         self.iterables.append(func)
 
     def remove_iterable(self, func):
         """
-        Remove a registered function(class-method) that is running indefinetly on the server.
+        Remove a registered function(class-method) that is running indefinitely on the server.
         """
         try:
             self.iterables.remove(func)
@@ -178,7 +178,7 @@ class ServerProtocol(LineReceiver):
 
     def remove_iterables(self):
         """
-        Remove all registered functions(class-method) that are running indefinetly on the server.
+        Remove all registered functions(class-method) that are running indefinitely on the server.
         """
         self.iterables = []
 
@@ -264,7 +264,7 @@ class ServerProtocol(LineReceiver):
     def packetParser(self, line):
         """
         This function is in charge of 'splitting' the packet header from the packet payload.
-        By default, it seperates the header from the payload by splitting the packet data from its colon(:).
+        By default, it separates the header from the payload by splitting the packet data from its colon(:).
         """
         header, payload = line.split(":")
         return header, payload
@@ -342,13 +342,13 @@ class ServerUDPProtocol(DatagramProtocol):
 
     def register_iterable(self, func):
         """
-        Register a function(class-method) that will run indefinetly on the server.
+        Register a function(class-method) that will run indefinitely on the server.
         """
         self.iterables.append(func)
 
     def remove_iterable(self, func):
         """
-        Remove a registered function(class-method) that is running indefinetly on the server.
+        Remove a registered function(class-method) that is running indefinitely on the server.
         """
         try:
             self.iterables.remove(func)
@@ -357,7 +357,7 @@ class ServerUDPProtocol(DatagramProtocol):
 
     def remove_iterables(self):
         """
-        Remove all registered functions(class-method) that are running indefinetly on the server.
+        Remove all registered functions(class-method) that are running indefinitely on the server.
         """
         self.iterables = []
 
@@ -398,7 +398,7 @@ class ServerUDPProtocol(DatagramProtocol):
     def packetParser(self, line):
         """
         This function is in charge of 'splitting' the packet header from the packet payload.
-        By default, it seperates the header from the payload by splitting the packet data from its colon(:).
+        By default, it separates the header from the payload by splitting the packet data from its colon(:).
         """
         header, payload = line.split(":")
         return header, payload

--- a/PyDark/vector2d.py
+++ b/PyDark/vector2d.py
@@ -35,7 +35,7 @@ class Vec2d(object):
         else:
             raise IndexError("Invalid subscript "+str(key)+" to Vec2d")
  
-    # String representaion (for debugging)
+    # String representation (for debugging)
     def __repr__(self):
         return 'Vec2d(%s, %s)' % (self.x, self.y)
  

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Overview
 ========
 PyDark runs on top of PyDark.engine.Scene objects. A scene is a collection of objects that are displayed within' the scene. Think of it like a movie scene, where a series of scenes define a movie.
 
-In a nutshell, you have a collection of modules avaialble to you, them being:
+In a nutshell, you have a collection of modules available to you, them being:
 1. PyDark.engine (core functionality, i.e.: Scenes, Sprites, etc).
 2. PyDark.ui (base UI elements for your game, integrate them into your games or build entirely new UI elements).
 3. PyDark.net (twisted networking TCP and UDP client/server networking classes)
@@ -150,7 +150,7 @@ game.start()
 
 Networking
 ==========
-Networking in PyDark is event-based and is built to keep things simple for client/server communication. One way PyDark acheives this is by supplying functions to modify python dictionaries that contain the make-up of your networking logic.
+Networking in PyDark is event-based and is built to keep things simple for client/server communication. One way PyDark achieves this is by supplying functions to modify python dictionaries that contain the make-up of your networking logic.
 
 An example of this is via PyDark.net.ServerProtocol.headers and PyDark.net.ClientProtocol.headers. These instance variables are python dictionaries that will contain (key, value) pairs consisting of (header, callback).
 
@@ -201,7 +201,7 @@ class OurProtocol(PyDark.net.ServerProtocol):
 ```
 *(Server protocol example)*
 
-**Note:** it is possible to use PyDark.net networking code outside an PyDark.engine.Game() instance. Take a look at the client.py and server.py examples on how to acheive that.
+**Note:** it is possible to use PyDark.net networking code outside an PyDark.engine.Game() instance. Take a look at the client.py and server.py examples on how to achieve that.
 
 **Real PyDark implementation**
 > The best and easiest way to create a networked game in PyDark is to create two (or more) files named client.py and server.py. Your client code should store your PyDark game and client networking logic (PyDark.net.ClientProtocol sub-class, Sprites, Tilsheets, Scenes, Mainloop, etc). While the server.py file should only store PyDark.net server networking logic.
@@ -224,7 +224,7 @@ Pay close attention to the `online=True`, `server_ip="localhost"`, `server_port=
 These inform PyDark that our game instance is an online game instance and we specify which IP and PORT to connect to. Finally,
 we specify our PyDark.net.ClientProtocol instance as the games networking protocol.
 
-In the back-end, PyDark will attempt to connect to the server. If a connection is successful, the instance variable `game.connection` will return a PyDark.net.TCP_Client instance and the instance variable `game.network` will return a PyDark.net.*Factory instance. Otherwise, both varaibles will be None.
+In the back-end, PyDark will attempt to connect to the server. If a connection is successful, the instance variable `game.connection` will return a PyDark.net.TCP_Client instance and the instance variable `game.network` will return a PyDark.net.*Factory instance. Otherwise, both variables will be None.
 
 
 


### PR DESCRIPTION
There are small typos in:
- PyDark/engine.py
- PyDark/net.py
- PyDark/vector2d.py
- README.md

Fixes:
- Should read `indefinitely` rather than `indefinetly`.
- Should read `whether` rather than `wether`.
- Should read `separates` rather than `seperates`.
- Should read `variables` rather than `varaibles`.
- Should read `representation` rather than `representaion`.
- Should read `receive` rather than `recieve`.
- Should read `inputted` rather than `inputed`.
- Should read `controls` rather than `controlls`.
- Should read `collision` rather than `collison`.
- Should read `available` rather than `avaialble`.
- Should read `achieves` rather than `acheives`.
- Should read `achieve` rather than `acheive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md